### PR TITLE
make issue reference optional; add LLM-powered context summarization

### DIFF
--- a/.github/workflows/pull-review.yml
+++ b/.github/workflows/pull-review.yml
@@ -232,6 +232,10 @@ jobs:
             printf '<pr_description>\n%s\n</pr_description>\n' "$SUMMARY" > /tmp/helpful_context.txt
           fi
 
+          echo "::group::Helpful context"
+          cat /tmp/helpful_context.txt
+          echo "::endgroup::"
+
       - name: Build review prompts
         run: |
           cat > /tmp/raw_prompt.txt << 'PROMPT_END'
@@ -364,6 +368,10 @@ jobs:
           echo "Raw review complete ($(wc -c < /tmp/raw_review.txt) bytes)"
           echo "RAW_REVIEW_OK=${RAW_REVIEW_OK:-false}" >> "$GITHUB_ENV"
 
+          echo "::group::Raw LLM review"
+          cat /tmp/raw_review.txt
+          echo "::endgroup::"
+
       - name: Install opencode
         if: steps.size-check.outputs.too_large == 'false'
         run: curl -fsSL https://opencode.ai/install | bash
@@ -396,6 +404,10 @@ jobs:
           }
 
           echo "Agentic review complete ($(wc -c < /tmp/agentic_review.txt) bytes)"
+
+          echo "::group::Agentic (opencode) review"
+          cat /tmp/agentic_review.txt
+          echo "::endgroup::"
 
       - name: Combine reviews
         if: steps.size-check.outputs.too_large == 'false'


### PR DESCRIPTION
## Summary

Removes the requirement for PRs to have a linked issue before the automated review can run. The workflow now proceeds for all PRs regardless of whether an issue is referenced.

A new **"Generate helpful context"** step replaces the old "Fetch issue contents" step:

- **If a referenced issue is found**: fetches the full issue conversation (body + all comments), summarizes it via the configured LLM, and injects the summary under `### Helpful Context` in `<issue_summary>` tags.
- **If no referenced issue is found**: fetches the PR description, summarizes it via the LLM (ignoring HTML markup from GitHub tools/AI agents; outputs empty string if blank), and injects the summary under `### Helpful Context` in `<pr_description>` tags.

Also includes the earlier formatting improvements to the combine-reviews prompt (sequential issue numbering, checkbox positioning).

## Review & Testing Checklist for Human

- [ ] **Trigger `/review` on a PR without a linked issue** — verify the workflow runs end-to-end and posts a review (previously it would post a rejection comment and stop)
- [ ] **Trigger `/review` on a PR with a linked issue** — verify the issue conversation is fetched, summarized, and included in the review prompt as `<issue_summary>`
- [ ] **Check the `jq -s 'add // []'` pattern** for merging paginated issue comments — confirm it handles 0, 1, and multi-page results correctly
- [ ] **Verify fallback behavior** — if the LLM summarization call fails (e.g. bad API key, rate limit), confirm the workflow still proceeds: falls back to raw issue text for issues, or empty string for PR descriptions
- [ ] **Review the `printf '<issue_summary>\n%s\n</issue_summary>\n'` usage** — confirm no edge cases with special characters in LLM output

### Suggested test plan
1. Open or find a PR **with** a linked issue (e.g. `Fixes #N`), comment `/review`, check the generated review includes an `<issue_summary>` block with a coherent summary
2. Open or find a PR **without** any linked issue, comment `/review`, confirm the workflow completes and the review includes a `<pr_description>` block (or empty tags if the description was blank/only HTML badges)
3. Optionally, temporarily misconfigure the API key to verify the fallback paths produce a sensible result rather than crashing the workflow

### Notes
- [Link to Devin run](https://app.devin.ai/sessions/4e30ca7336974986b84fdd2caae23459)
- Requested by @taoeffect

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/okturtles/libcheloniajs/pull/50" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->