### PR TITLE
Fix review re-run suggestion to echo the original command

### DIFF
--- a/.github/workflows/pull-review-crush.yml
+++ b/.github/workflows/pull-review-crush.yml
@@ -53,7 +53,7 @@ jobs:
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
-          REVIEW_COMMAND=$(echo "$COMMENT_BODY" | grep -oP '^\s*/\S+(\s+\{\{[^}]*\}\})?' | xargs)
+          REVIEW_COMMAND=$(echo "$COMMENT_BODY" | grep -m1 -oP '^\s*\K/\S+(\s+\{\{[^}]*\}\})?')
           echo "REVIEW_COMMAND=$REVIEW_COMMAND" >> "$GITHUB_ENV"
           if echo "$COMMENT_BODY" | grep -qP '^\s*/crush_fast'; then
             echo "FAST_MODE=true" >> "$GITHUB_ENV"

--- a/.github/workflows/pull-review.yml
+++ b/.github/workflows/pull-review.yml
@@ -53,7 +53,7 @@ jobs:
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
-          REVIEW_COMMAND=$(echo "$COMMENT_BODY" | grep -oP '^\s*/\S+(\s+\{\{[^}]*\}\})?' | xargs)
+          REVIEW_COMMAND=$(echo "$COMMENT_BODY" | grep -m1 -oP '^\s*\K/\S+(\s+\{\{[^}]*\}\})?')
           echo "REVIEW_COMMAND=$REVIEW_COMMAND" >> "$GITHUB_ENV"
           if echo "$COMMENT_BODY" | grep -qP '^\s*/review_fast'; then
             echo "FAST_MODE=true" >> "$GITHUB_ENV"


### PR DESCRIPTION

## Summary

- The re-run suggestion in review workflow comments was hardcoded to `/review`, which is wrong when using provider overrides (e.g., `/crush_fast {{openrouter, google/gemini-3.1-pro-preview}}`) or the crush workflow.
- Now extracts the actual command + optional `{{ }}` parameters from the comment body and echoes it back in both success and failure messages.

Closes #56
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/okturtles/libcheloniajs/pull/57" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
